### PR TITLE
feat: better doc for adaparse and some changes

### DIFF
--- a/benchmarks/performancecounters/apple_arm_events.h
+++ b/benchmarks/performancecounters/apple_arm_events.h
@@ -966,11 +966,9 @@ struct AppleEvents {
   u64 counters_1[KPC_MAX_COUNTERS] = {0};
   static constexpr usize ev_count =
       sizeof(profile_events) / sizeof(profile_events[0]);
-
+  bool init = false;
+  bool worked = false;
   inline bool setup_performance_counters() {
-    static bool init = false;
-    static bool worked = false;
-
     if (init) {
       return worked;
     }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,7 +14,7 @@
 Well-formatted URL: 
 
 ```bash 
-./buildbench/tools/adaparse "http://www.google.com"
+adaparse "http://www.google.com"
 ```
 Output: 
 
@@ -25,7 +25,7 @@ http://www.google.com
 Ill-formatted URL: 
 
 ```bash 
-./buildbench/tools/adaparse "h^tp:ws:/www.g00g.com"
+adaparse "h^tp:ws:/www.g00g.com"
 ```
 Output: 
 
@@ -37,7 +37,7 @@ Invalid URL: h^tp:ws:/www.g00g.com
 Diagram flag:
 
 ```bash
- $ ./buildbench/tools/adaparse -d http://www.google.com/bal\?a\=\=11\#fddfds
+ $ adaparse -d http://www.google.com/bal\?a\=\=11\#fddfds
  ```
 
 Output:
@@ -58,10 +58,13 @@ Output:
 
 ### Piping Example
 
-Ada can process URLs from piped input, making it easy to integrate with other command-line tools. Here's an example of how to pipe the output of another command into Ada. 
+Ada can process URLs from piped input, making it easy to integrate with other command-line tools. Here's an example of how to pipe the output of another command into Ada.
+
+Given a list of URLs, one by line, we may query the normalized URL string (`href`)
+and detect any malformed URL:
 
 ```bash
-cat dragonball_url.txt | ./buildbench/tools/adaparse
+cat dragonball_url.txt | adaparse -get href
 ```
 
 Output:
@@ -72,10 +75,13 @@ http://www.gohan.com
 
 ```
 
-It also supports the passing of arguments to each URL in said file: 
+Our tool supports the passing of arguments to each URL in said file so
+that you can query for the hash, the host, the protocol, the port, 
+the origin, the search, the password, the username, the pathname
+or the hostname:
 
 ```bash
-cat dragonball_url.txt  | ./buildbench/tools/adaparse -g host
+cat dragonball_url.txt  | adaparse -g host
 ```
 
 Output:
@@ -85,36 +91,45 @@ www.vegeta.com
 www.gohan.com
 ```
 
+If you omit `-g`, it will only provide a list of invalid URLs. This might be
+useful if you want to valid quickly a list of URLs.
+
+
 The benchmark flag can be used to output the time it takes to process piped input:
 
 ```bash
-cat wikipedia_100k.txt | ./buildbench/tools/adaparse -b
+cat wikipedia_100k.txt | adaparse -b
 ```
 
 ```bash
-(---snip---)
-file:///opt 
-file:///Users 
-file:///Users/lemire 
-file:///Users/lemire/tmp 
-file:///Users/lemire/tmp/linuxdump 
-file:///Users/lemire/tmp/linuxdump/linuxfiles.txt 
-file:///.dockerenv 
-read 10124906 bytes in 3071328453 ns using 169312 lines
-0.003296588481153891 GB/s
+Invalid URL:1968:_Die_Kinder_der_Diktatur
+Invalid URL:58957:_The_Bluegrass_Guitar_Collection
+Invalid URL:650luc:_Gangsta_Grillz
+Invalid URL:Q4%3A57
+Invalid URL:Q10%3A47
+Invalid URL:Q5%3A45
+Invalid URL:Q40%3A28
+Invalid URL:1:1_scale
+Invalid URL:1893:_A_World's_Fair_Mystery
+Invalid URL:12:51_(Krissy_%26_Ericka_song)
+Invalid URL:111:_A_Nelson_Number
+Invalid URL:7:00AM-8%3A00AM_(24_season_5)
+Invalid URL:Q53%3A31
+read 5209265 bytes in 32819917 ns using 100000 lines, used 160 loads
+0.1587226744053009 GB/s
 ```
 
 There is an option to output to a file on disk:
 
 ```bash 
 
-cat wikipedia_100k.txt | ./buildbench/tools/adaparse -o wiki_output.txt
+cat wikipedia_100k.txt | adaparse -o wiki_output.txt
 ```
 
 as well as read in from a file on disk without going through cat: 
 
 ```bash
-./buildbench/tools/adaparse -p wikipedia_top_100_txt
+adaparse -p wikipedia_top_100_txt
 ```
 
 You may also combine different flags together. E.g. Say one wishes to extract only the host from URLs stored in wikipedia.txt and output it to the test_write.txt file:
@@ -144,3 +159,39 @@ en.wikipedia.org
 en.wikipedia.org
 (---snip---)
 ```
+
+### Performance
+
+Our `adaparse` tool may outperform other popular alternatives. We offer a [collection of
+sets of URLs](https://github.com/ada-url/url-various-datasets) for benchmarking purposes.
+The following results are on a macBook Air 2022 (M2 processor) using LLVM 14. We
+compare against trurl version 0.6 (libcurl/7.87.0).
+
+
+On the wikipedia_100k dataset, we get that adaparse can generate normalized URLs about three
+times faster than trurl:
+
+```
+$ time cat url-various-datasets/wikipedia/wikipedia_100k.txt| trurl --url-file - &> /dev/null   1
+cat url-various-datasets/wikipedia/wikipedia_100k.txt  0,00s user 0,01s system 3% cpu 0,179 total
+trurl --url-file - &> /dev/null  0,14s user 0,03s system 98% cpu 0,180 total
+
+
+$ time cat url-various-datasets/wikipedia/wikipedia_100k.txt| ./build/tools/cli/adaparse -g href &> /dev/null
+cat url-various-datasets/wikipedia/wikipedia_100k.txt  0,00s user 0,00s system 10% cpu 0,056 total
+./build/tools/cli/adaparse -g href &> /dev/null  0,05s user 0,00s system 93% cpu 0,055 total
+````
+
+On the top100 dataset, the adaparse tool is twice as fast as the trurl:
+
+```
+$ time cat url-various-datasets/top100/top100.txt| trurl --url-file - &> /dev/null              1
+cat url-various-datasets/top100/top100.txt  0,00s user 0,00s system 4% cpu 0,115 total
+trurl --url-file - &> /dev/null  0,09s user 0,02s system 97% cpu 0,113 total
+
+$ time cat url-various-datasets/top100/top100.txt| ./build/tools/cli/adaparse -g href &> /dev/null
+cat url-various-datasets/top100/top100.txt  0,00s user 0,01s system 11% cpu 0,062 total
+./build/tools/cli/adaparse -g href &> /dev/null  0,05s user 0,00s system 94% cpu 0,061 total
+```
+
+The results will vary depending on your system. We invite you to run your own benchmarks.

--- a/tools/cli/adaparse.cpp
+++ b/tools/cli/adaparse.cpp
@@ -145,7 +145,7 @@ int piped_file(Callable&& adaparse_print, const cxxopts::ParseResult result,
 
     double seconds = (after - before) / 1000000000.;
     double speed = giga / seconds;
-    fmt::print("{} GB/s", speed);
+    fmt::print("{} GB/s\n", speed);
   }
 
   return EXIT_SUCCESS;

--- a/tools/cli/adaparse.cpp
+++ b/tools/cli/adaparse.cpp
@@ -22,7 +22,10 @@ bool print_part(Callable&& fmt_or_adaparse_print, std::string_view get_part,
                 const ada::url_aggregator& url) {
   if (get_part.size() == 4) {
     if (get_part[0] == 'h') {
-      if (get_part == "host") {
+      if (get_part == "href") {
+        fmt_or_adaparse_print("{}\n", url.get_href());
+        return true;
+      } else if (get_part == "host") {
         fmt_or_adaparse_print("{}\n", url.get_host());
         return true;
       } else if (get_part == "hash") {
@@ -91,7 +94,6 @@ int piped_file(Callable&& adaparse_print, const cxxopts::ParseResult result,
   size_t lines = 0;
   size_t sum_of_lines_bytes = 0;
   size_t blocks = 0;
-
   std::string get_part;
   if (result.count("get")) {
     get_part = result["get"].as<std::string>();
@@ -112,15 +114,9 @@ int piped_file(Callable&& adaparse_print, const cxxopts::ParseResult result,
 
       ada::result<ada::url_aggregator> url = ada::parse(line);
       if (!url) {
-        adaparse_print("Invalid URL:{}\n", line);
-
-      } else if (result.count("get")) {
-        std::string get_part = result["get"].as<std::string>();
+        fmt::print(stderr, "Error opening file: {}\n", strerror(err)); shit
+      } else if (!get_part.empty()) {
         print_part(adaparse_print, get_part, url.value());
-      }
-
-      else {
-        adaparse_print("{}\n", url->get_href());
       }
 
       lines++;
@@ -131,6 +127,15 @@ int piped_file(Callable&& adaparse_print, const cxxopts::ParseResult result,
   }
   if (offset > 0) {
     // have a line of length offset at cachebuffer.get()
+    std::string_view line(cachebuffer.get(), offset);
+
+    ada::result<ada::url_aggregator> url = ada::parse(line);
+    if (!url) {
+      adaparse_print("Invalid URL:{}\n", line);
+    } else if (!get_part.empty()) {
+      print_part(adaparse_print, get_part, url.value());
+    }
+
     lines++;
   }
 
@@ -218,12 +223,13 @@ int main(int argc, char** argv) {
       : output_filename = result["output"].as<std::string>();
 
   auto out = fmt::output_file(output_filename);
+  bool has_result = result.count("output");
 
-  auto adaparse_print = [&result, &out](const std::string& format_str,
+  auto adaparse_print = [has_result, &out](const std::string& format_str,
                                         auto&&... args) {
     std::string formatted_str =
         fmt::format(format_str, std::forward<decltype(args)>(args)...);
-    if (result.count("output")) {
+    if (has_result) {
       out.print(formatted_str);
     } else {
       fmt::print("{}", formatted_str);


### PR DESCRIPTION
- [X] In some cases, adaparse could omit the last line, this PR fixes that.
- [X] We call `count` less often. Note that there are other possible performance optimization possible.
- [X] I ran some benchmarks against trurl, and I include some documentation in the documentation.
- [X] I propose that when piping a list of URLs through the tool, we only print out the invalid URLs by default. If someone wants to get the href, they call add `-g href`.
- [X] I have added the `href` getter
- [X] There is a minor issue (unrelated) in apple_arm_events.h that I try very hard to get fixed...
- [X] In some cases, we would omit flushing the last line of output (when benchmarking).

There is much more we could do, of course, such as batched setters and so forth.